### PR TITLE
Use n-logger to replace Papertrail with Splunk

### DIFF
--- a/app/logger.js
+++ b/app/logger.js
@@ -1,10 +1,1 @@
-const winston = require('winston');
-const config = require('../config');
-
-winston.level = config.logLevel;
-
-if (config.NODE_ENV === 'test') {
-  winston.remove(winston.transports.Console);
-}
-
-module.exports = winston;
+module.exports = require('@financial-times/n-logger').default;

--- a/config.js
+++ b/config.js
@@ -9,7 +9,6 @@ function int(str) {
 
 config.NODE_ENV = process.env.NODE_ENV || 'development';
 config.port = int(process.env.PORT) || 3000;
-config.logLevel = process.env.LOG_LEVEL || 'info';
 
 // VoltDB
 config.voltHost = process.env.VOLT_HOST || 'spoor-voltdb.in.ft.com';

--- a/package.json
+++ b/package.json
@@ -18,14 +18,14 @@
   },
   "homepage": "https://github.com/Financial-Times/ip-voltdb-service#readme",
   "dependencies": {
+    "@financial-times/n-logger": "^5.5.7",
     "body-parser": "^1.17.2",
     "compression": "^1.7.0",
     "dotenv": "^4.0.0",
     "express": "^4.15.4",
     "forwarded": "^0.1.2",
     "fresh": "^0.5.2",
-    "voltjs": "github:snozza/voltdb-client-nodejs",
-    "winston": "^2.3.1"
+    "voltjs": "github:snozza/voltdb-client-nodejs"
   },
   "devDependencies": {
     "eslint": "^4.4.1",


### PR DESCRIPTION
[n-logger](https://github.com/Financial-Times/n-logger) sends logs to Splunk when `process.env.NODE_ENV === 'production'`

It needs a `SPLUNK_URL` environment variable, which I’ll add to the relevant places